### PR TITLE
Use bower for Buildkit

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "src/bower"
+  "directory": "public/bower"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules
+public/bower
 
 # testing
 coverage

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-starter",
+  "description": "",
+  "main": "index.js",
+  "authors": [
+    "Estella Gonzalez Madison <emadison@blurb.com>",
+    "Tammy Soo <tsoo@blurb.com>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "React"
+  ],
+  "dependencies": {
+    "buildkit": "https://s3-us-west-2.amazonaws.com/blurb-books-build-artifacts/jobs/Buildkit-Artifact/1214/buildkit-dist.tgz"
+  },
+  "homepage": "https://github.com/blurb/react-buildkit",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "stylus": "^0.54.5"
   },
   "dependencies": {
-    "blurb-buildkit": "https://s3-us-west-2.amazonaws.com/blurb-books-build-artifacts/jobs/Buildkit-Artifact/1214/buildkit-dist.tgz",
     "counterpart": "^0.17.6",
     "history": "4.2.0",
     "react": "~15.4.0",

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" type="image/ico" href="/favicon.ico">
+    <link rel="stylesheet" type="text/css" href="bower/buildkit/assets/css/main-drupal.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tag above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -34,6 +35,8 @@
       To begin the development, run `npm start`.
       To create a production bundle, use `npm run build`.
     -->
+    <script src="bower/buildkit/assets/js/vendor/modernizr/modernizr-custom.min.js"></script>
+    <script src="bower/buildkit/assets/js/main.js"></script>
     <script>
     (function(d) {
       var config = { kitId: 'tar4yyp', scriptTimeout: 3000, async: true },

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,6 @@ import ReactDOM from 'react-dom';
 import App from './components/App';
 import Header from './components/Header';
 import './css/index.css';
-import '../node_modules/blurb-buildkit/assets/css/main-drupal.css';
-// eslint-disable-next-line
-import Modernizr from '../node_modules/blurb-buildkit/assets/js/vendor/modernizr/modernizr-custom.min.js';
-// eslint-disable-next-line
-import Buildkit from '../node_modules/blurb-buildkit/assets/js/mainReact.js';
 
 ReactDOM.render(
   <Header />,


### PR DESCRIPTION
I hadn't realized the bower files would need to go under the `public` directory. This fixes issues with WebPack loading Buildkit, and means we no longer need to maintain a separate `mainReact.js` file in Buildkit. This also means components that require i18n will work with React.